### PR TITLE
Feature/pretty up locations

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,3 +1,5 @@
+.git/*
+.github/*
 node_modules/*
 dist/*
 android/*

--- a/TODO.txt
+++ b/TODO.txt
@@ -8,10 +8,11 @@
 * View list of pokemon by point in game
 * View moves available at point in game
 * Pretty up details display
-Route based on pokemonId (/details/:id)
+* Route based on pokemonId (/details/:id)
 Pretty up locations/points in game display
 - Use Card UI Transition https://codepen.io/ivillamil/pen/obWaOX
 - Replace list with grid of cards
 Dark Mode
 Add homepage explaining how to use the app (do not route to /locations)
-Add proper typescript types
+Dropdown search
+Dropdown start at last selected

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,9 +1,14 @@
 server {
     root /var/www/html;
     listen 8080;
+    error_page 404 /reborn-pokepedia/404.html;
     location / {
         return 301 /reborn-pokepedia/;
     }
     location /reborn-pokepedia/ {
+    }
+    location /reborn-pokepedia/404.html {
+        #prevent external access to this route
+        internal;
     }
 }

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,5 @@
+<script>
+    const path = window.location.pathname.replace("/reborn-pokepedia", "");
+    localStorage.setItem('path', path);
+    window.location.href = '../';
+</script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -176,10 +176,6 @@ ion-menu.ios ion-item ion-icon {
   color: #73849a;
 }
 
-ion-menu.ios ion-list#labels-list ion-list-header {
-  margin-bottom: 8px;
-}
-
 ion-menu.ios ion-list-header,
 ion-menu.ios ion-note {
   padding-left: 16px;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,32 +1,40 @@
-import { createApp } from 'vue'
-import App from './App.vue'
-import router from './router';
+import { createApp } from "vue";
+import App from "./App.vue";
+import router from "./router";
 
-import { IonicVue } from '@ionic/vue';
+import { IonicVue } from "@ionic/vue";
 
 /* Core CSS required for Ionic components to work properly */
-import '@ionic/vue/css/core.css';
+import "@ionic/vue/css/core.css";
 
 /* Basic CSS for apps built with Ionic */
-import '@ionic/vue/css/normalize.css';
-import '@ionic/vue/css/structure.css';
-import '@ionic/vue/css/typography.css';
+import "@ionic/vue/css/normalize.css";
+import "@ionic/vue/css/structure.css";
+import "@ionic/vue/css/typography.css";
 
 /* Optional CSS utils that can be commented out */
-import '@ionic/vue/css/padding.css';
-import '@ionic/vue/css/float-elements.css';
-import '@ionic/vue/css/text-alignment.css';
-import '@ionic/vue/css/text-transformation.css';
-import '@ionic/vue/css/flex-utils.css';
-import '@ionic/vue/css/display.css';
+import "@ionic/vue/css/padding.css";
+import "@ionic/vue/css/float-elements.css";
+import "@ionic/vue/css/text-alignment.css";
+import "@ionic/vue/css/text-transformation.css";
+import "@ionic/vue/css/flex-utils.css";
+import "@ionic/vue/css/display.css";
 
 /* Theme variables */
-import './theme/variables.css';
+import "./theme/variables.css";
 
 const app = createApp(App)
   .use(IonicVue)
   .use(router);
-  
+
 router.isReady().then(() => {
-  app.mount('#app');
+  app.mount("#app");
+  // Need to get path after app is mounted
+  // Then redirect based on whatever path is
+  // https://github.com/geeksilva97/geeksilva97.github.io
+  const path = localStorage.getItem("path");
+  if (path) {
+    localStorage.removeItem("path");
+    router.push(path);
+  }
 });

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,8 +24,8 @@ const routes: Array<RouteRecordRaw> = [
   },
   {
     path: "/details2",
-    component: () => import("../views/Details2.vue")
-  }
+    component: () => import("../views/Details2.vue"),
+  },
 ];
 
 const router = createRouter({

--- a/src/views/Details.vue
+++ b/src/views/Details.vue
@@ -245,22 +245,6 @@ export default defineComponent({
       pokemonData70,
       pokemonData71
     );
-    const getIdNumberFromRoute = (id: string | string[]): number => {
-      let numId = 0;
-      if (!id) {
-        return numId;
-      }
-      if (typeof id === "string") {
-        numId = parseInt(id);
-      } else if (id.length > 0) {
-        numId = parseInt(id[0]);
-      }
-      if (numId > -1 && numId < pokemonData.length) {
-        return numId;
-      } else {
-        return 0;
-      }
-    };
     const route = useRoute();
     let moveList: string[] = [];
     let ptLevel = ref(0);
@@ -317,6 +301,23 @@ export default defineComponent({
         .forEach((mv) => moveList.push(mv.name));
     };
 
+    const getIdNumberFromRoute = (id: string | string[]): number => {
+      let numId = 0;
+      if (!id) {
+        return numId;
+      }
+      if (typeof id === "string") {
+        numId = parseInt(id);
+      } else if (id.length > 0) {
+        numId = parseInt(id[0]);
+      }
+      if (numId > 1) {
+        return numId;
+      } else {
+        return 1;
+      }
+    };
+
     const determinePokemonSel = (
       id: string | string[],
       pk: Pokemon | undefined
@@ -326,7 +327,12 @@ export default defineComponent({
         pokemonSel.value = pk;
       } else {
         isModal.value = false;
-        pokemonSel.value = pokemonData[getIdNumberFromRoute(id)];
+        pokemonSel.value = pokemonData.filter(
+          (pk) => pk.no == getIdNumberFromRoute(id)
+        )[0];
+        if (!pokemonSel.value) {
+          pokemonSel.value = pokemonData[0];
+        }
       }
     };
 

--- a/src/views/Details.vue
+++ b/src/views/Details.vue
@@ -164,7 +164,7 @@ import {
   IonSelectOption,
   IonText,
 } from "@ionic/vue";
-import { defineComponent, ref } from "vue";
+import { defineComponent, onMounted, ref } from "vue";
 import { useRoute } from "vue-router";
 import { pokemonData10 } from "@/data/gen1_0";
 import { pokemonData11 } from "@/data/gen1_1";
@@ -185,6 +185,7 @@ import { pokemonData70 } from "@/data/gen7_0";
 import { pokemonData71 } from "@/data/gen7_1";
 import { gamePoints, statOrder } from "@/data/reborn";
 import { tmLocations, tutorLocations } from "@/data/tm_locations";
+import { Pokemon } from "@/interfaces/pokemon_interfaces";
 
 export default defineComponent({
   components: {
@@ -200,7 +201,13 @@ export default defineComponent({
     IonSelectOption,
     IonText,
   },
-  setup() {
+  props: {
+    pk: {
+      type: Object as () => Pokemon,
+      required: false,
+    },
+  },
+  setup(props) {
     const pokemonData = pokemonData10.concat(
       pokemonData11,
       pokemonData12,
@@ -238,7 +245,7 @@ export default defineComponent({
     const route = useRoute();
     let moveList: string[] = [];
     let ptLevel = ref(0);
-    const pokemonSel = ref(pokemonData[getIdNumberFromRoute(route.params.id)]);
+    const pokemonSel = ref(pokemonData[0]);
     const pokemonPath = () => {
       return (
         process.env.BASE_URL + "assets/pokemon/" + pokemonSel.value.no + ".png"
@@ -289,6 +296,20 @@ export default defineComponent({
         .filter((mv) => cumulativePoints.includes(mv.point))
         .forEach((mv) => moveList.push(mv.name));
     };
+
+    const determinePokemonSel = (
+      id: string | string[],
+      pk: Pokemon | undefined
+    ): void => {
+      if (pk) {
+        pokemonSel.value = pk;
+      } else {
+        pokemonSel.value = pokemonData[getIdNumberFromRoute(id)];
+      }
+    };
+
+    onMounted(() => determinePokemonSel(route.params.id, props.pk));
+
     return {
       moveList,
       pokemonSel,

--- a/src/views/Details.vue
+++ b/src/views/Details.vue
@@ -1,7 +1,7 @@
 <template>
   <ion-page>
     <ion-content>
-      <ion-item>
+      <ion-item v-if="!isModal">
         <ion-label>Select a Pokemon</ion-label>
         <ion-select v-model="pokemonSel">
           <ion-select-option
@@ -26,7 +26,11 @@
       </ion-item>
       <ion-grid class="ion-margin-top ion-margin-bottom">
         <ion-row class="ion-align-items-start">
-          <ion-col size="12" size-sm="4" class="ion-text-center">
+          <ion-col
+            size="12"
+            :size-sm="isModal ? 12 : 4"
+            class="ion-text-center"
+          >
             <ion-img :src="pokemonPath()"></ion-img>
             <ion-text color="light" class="bg-dark title-box">{{
               pokemonSel.name
@@ -69,6 +73,7 @@
             <ion-row>
               <ion-col
                 size="1"
+                :size-xl="isModal ? 2 : 1"
                 class="ion-text-center ion-align-items-center"
                 style="display: flex"
               >
@@ -90,7 +95,7 @@
             <ion-row>
               <ion-col
                 size="2"
-                size-xl="1"
+                :size-xl="isModal ? 2 : 1"
                 class="ion-text-center ion-align-items-center"
                 style="display: flex"
               >
@@ -147,6 +152,12 @@
           </ion-grid>
         </ion-row>
       </ion-grid>
+      <ion-fab v-if="isModal" vertical="bottom" horizontal="end" slot="fixed">
+        <ion-fab-button
+          activated="true"
+          @click="modalCallback"
+        ></ion-fab-button>
+      </ion-fab>
     </ion-content>
   </ion-page>
 </template>
@@ -154,6 +165,8 @@
 import {
   IonCol,
   IonContent,
+  IonFab,
+  IonFabButton,
   IonGrid,
   IonImg,
   IonItem,
@@ -191,6 +204,8 @@ export default defineComponent({
   components: {
     IonCol,
     IonContent,
+    IonFab,
+    IonFabButton,
     IonGrid,
     IonImg,
     IonItem,
@@ -204,6 +219,10 @@ export default defineComponent({
   props: {
     pk: {
       type: Object as () => Pokemon,
+      required: false,
+    },
+    modalCallback: {
+      type: Function as () => void,
       required: false,
     },
   },
@@ -245,6 +264,7 @@ export default defineComponent({
     const route = useRoute();
     let moveList: string[] = [];
     let ptLevel = ref(0);
+    const isModal = ref(false);
     const pokemonSel = ref(pokemonData[0]);
     const pokemonPath = () => {
       return (
@@ -302,8 +322,10 @@ export default defineComponent({
       pk: Pokemon | undefined
     ): void => {
       if (pk) {
+        isModal.value = true;
         pokemonSel.value = pk;
       } else {
+        isModal.value = false;
         pokemonSel.value = pokemonData[getIdNumberFromRoute(id)];
       }
     };
@@ -311,6 +333,7 @@ export default defineComponent({
     onMounted(() => determinePokemonSel(route.params.id, props.pk));
 
     return {
+      isModal,
       moveList,
       pokemonSel,
       pokemonData,

--- a/src/views/Locations.vue
+++ b/src/views/Locations.vue
@@ -5,17 +5,17 @@
         <ion-label>Select a Location</ion-label>
         <ion-select @ionChange="pokemonAvailable($event)">
           <ion-select-option
-            v-for="(pnt, idx) in gameLocations"
+            v-for="(loc, idx) in gameLocations"
             :key="idx"
-            :value="pnt"
-            >{{ pnt }}</ion-select-option
+            :value="loc"
+            >{{ loc }}</ion-select-option
           >
         </ion-select>
       </ion-item>
       <ion-list>
-        <ion-item v-for="pk in pointInGame" :key="pk.no">
+        <ion-item v-for="pk in pokemonAtLocation" :key="pk.no">
           <ion-thumbnail slot="start">
-            <img :src="pokemonPath2(pk.no)" />
+            <img :src="pokemonPath(pk.no)" />
           </ion-thumbnail>
           <ion-label>
             <h3>{{ pk.name }}</h3>
@@ -28,46 +28,26 @@
               />
             </ion-thumbnail>
           </ion-label>
-          <ion-col>
-            <ion-row>
-              <ion-col
-                class="ion-text-center"
-                v-for="(stat, i) in pk.stats"
-                :key="i"
-              >
-                <ion-badge color="secondary">{{ stat }}</ion-badge>
-                <br />
-                <ion-text color="medium" style="font-size: 0.8em">{{
-                  statOrder[i]
-                }}</ion-text>
-              </ion-col>
-            </ion-row></ion-col
-          >
-          <ion-col>
-            <ion-text>{{ pk.locations[0].point }}</ion-text>
-          </ion-col>
+          <ion-text>{{ pokemonLocation(pk).point }}</ion-text>
         </ion-item>
       </ion-list>
     </ion-content>
   </ion-page>
 </template>
 
-<script>
+<script lang="ts">
 import {
-  IonBadge,
-  IonCol,
   IonContent,
   IonItem,
   IonLabel,
   IonList,
   IonPage,
-  IonRow,
   IonSelect,
   IonSelectOption,
   IonText,
   IonThumbnail,
 } from "@ionic/vue";
-import { defineComponent, ref, reactive } from "vue";
+import { defineComponent, reactive } from "vue";
 import { pokemonData10 } from "@/data/gen1_0";
 import { pokemonData11 } from "@/data/gen1_1";
 import { pokemonData12 } from "@/data/gen1_2";
@@ -85,26 +65,24 @@ import { pokemonData60 } from "@/data/gen6_0";
 import { pokemonData61 } from "@/data/gen6_1";
 import { pokemonData70 } from "@/data/gen7_0";
 import { pokemonData71 } from "@/data/gen7_1";
-import { gamePoints, gameLocations, statOrder } from "@/data/reborn";
+import { gameLocations } from "@/data/reborn";
+import { Pokemon } from "@/interfaces/pokemon_interfaces";
 
 export default defineComponent({
   components: {
-    IonBadge,
-    IonCol,
     IonContent,
     IonItem,
     IonLabel,
     IonList,
     IonPage,
-    IonRow,
     IonSelect,
     IonSelectOption,
     IonText,
     IonThumbnail,
   },
   setup() {
-    let pointInGame = reactive([]);
-    const pokemonId = ref(1);
+    let pokemonAtLocation: Pokemon[] = reactive([]);
+    let locationInGame = "";
     const pokemonData = pokemonData10.concat(
       pokemonData11,
       pokemonData12,
@@ -123,43 +101,33 @@ export default defineComponent({
       pokemonData70,
       pokemonData71
     );
-    const pokemonPath = () => {
-      return (
-        process.env.BASE_URL + "assets/pokemon/" + pokemonId.value + ".png"
-      );
-    };
-    const pokemonPath2 = (pkId) => {
+    const pokemonPath = (pkId: number) => {
       return process.env.BASE_URL + "assets/pokemon/" + pkId + ".png";
     };
-    const pokemonTypePath = (typeStr) => {
+    const pokemonTypePath = (typeStr: string) => {
       return process.env.BASE_URL + "assets/types/" + typeStr + ".png";
     };
-    const pokemonAvailable = (event) => {
+    const pokemonLocation = (pk: Pokemon) => {
+      return pk.locations.filter((loc) => loc.location === locationInGame)[0];
+    };
+    const pokemonAvailable = (event: any) => {
       // Clear the reactive array
-      pointInGame.splice(0, pointInGame.length);
+      pokemonAtLocation.splice(0, pokemonAtLocation.length);
+
+      // Set current point in game to whatever was in the event
+      locationInGame = event.target.value;
 
       // Filter for pokemon and then add them to the reactive array
       pokemonData
-        .filter((pk, idx, arr) => {
-          if (!pk.locations) {
-            return false;
-          }
-          return pk.locations.find(
-            (loc) => loc.location === event.target.value
-          );
-        })
-        .forEach((e) => pointInGame.push(e));
+        .filter((pk, idx, arr) => pokemonLocation(pk))
+        .forEach((e) => pokemonAtLocation.push(e));
     };
     return {
-      pointInGame,
-      pokemonId,
-      pokemonData,
-      gamePoints,
+      pokemonAtLocation,
       gameLocations,
-      statOrder,
       pokemonPath,
-      pokemonPath2,
       pokemonTypePath,
+      pokemonLocation,
       pokemonAvailable,
     };
   },

--- a/src/views/Locations.vue
+++ b/src/views/Locations.vue
@@ -17,9 +17,9 @@
           <ion-thumbnail slot="start">
             <img :src="pokemonPath(pk.no)" />
           </ion-thumbnail>
-          <ion-label>
-            <h3>{{ pk.name }}</h3>
-            <ion-thumbnail class="ion-margin-start">
+          <ion-label class="title">
+            <ion-text>{{ pk.name }}</ion-text>
+            <ion-thumbnail class="ion-margin-start ion-margin-top">
               <img
                 v-for="type in pk.types"
                 :key="type"
@@ -28,7 +28,18 @@
               />
             </ion-thumbnail>
           </ion-label>
-          <ion-text>{{ pokemonLocation(pk).point }}</ion-text>
+          <ion-col size-lg="9">
+            <ion-row class="method">
+              <ion-text>
+                {{ pokemonLocation(pk).method }}
+              </ion-text>
+            </ion-row>
+            <ion-row class="point">
+              <ion-text>
+                {{ pokemonLocation(pk).point }}
+              </ion-text>
+            </ion-row>
+          </ion-col>
         </ion-item>
       </ion-list>
     </ion-content>
@@ -37,11 +48,13 @@
 
 <script lang="ts">
 import {
+  IonCol,
   IonContent,
   IonItem,
   IonLabel,
   IonList,
   IonPage,
+  IonRow,
   IonSelect,
   IonSelectOption,
   IonText,
@@ -70,11 +83,13 @@ import { Pokemon } from "@/interfaces/pokemon_interfaces";
 
 export default defineComponent({
   components: {
+    IonCol,
     IonContent,
     IonItem,
     IonLabel,
     IonList,
     IonPage,
+    IonRow,
     IonSelect,
     IonSelectOption,
     IonText,
@@ -133,3 +148,60 @@ export default defineComponent({
   },
 });
 </script>
+<style scoped>
+ion-list > ion-item {
+  --background: rgba(var(--ion-color-primary-rgb), 0.05);
+  font-family: "Franklin Gothic Medium", "Arial Narrow", Arial, sans-serif;
+}
+
+@media screen and (max-width: 768px) {
+  .title {
+    font-weight: bolder;
+    font-style: italic;
+    padding: 2px;
+    font-size: 1.1em;
+  }
+  .method {
+    font-size: 1.05em;
+    font-weight: bold;
+    margin: 0px;
+    color: var(--ion-color-medium, --ion-color-dark);
+  }
+
+  .point {
+    font-size: 0.95em;
+    font-weight: 300;
+    font-style: italic;
+    margin: 0px;
+    color: var(--ion-color-medium, --ion-color-dark);
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .title {
+    font-weight: bolder;
+    font-style: italic;
+    padding: 2px;
+    font-size: 1.25em;
+  }
+
+  .method {
+    font-size: 1.15em;
+    font-weight: bold;
+    margin: 0px;
+    color: var(--ion-color-medium, --ion-color-dark);
+  }
+
+  .point {
+    font-size: 1em;
+    font-weight: 300;
+    font-style: italic;
+    margin: 0px;
+    color: var(--ion-color-medium, --ion-color-dark);
+  }
+}
+
+body {
+  background-color: #eeeeee;
+}
+</style>


### PR DESCRIPTION
**Descriptive Title**
Adds more functionality to the pokemon locations screen

**Changes**
pokemon can now be clicked and generate a modal containing their details. each pokemon item now only shows the point and method when they can be obtained, accurate to the first occurrence of the pokemon at the location based on their location array. colorizes pokemon locations to be better in light or dark mode. enables pokemon details to be rendered as a modal with appropriate DOM manipulation to accommodate the use.  repairs the details id route to always have a valid pokemon and for the id to be matched to whatever pokemon has that number rather than the index number in the pokemonData array.
