### PR TITLE
Update to v4

### DIFF
--- a/.github/workflows/androidApp.yml
+++ b/.github/workflows/androidApp.yml
@@ -9,16 +9,16 @@ jobs:
   build_android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: "zulu"
           java-version: "17"
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "21"
           cache: "npm"

--- a/.github/workflows/webApp.yml
+++ b/.github/workflows/webApp.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build Vue
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: Build-Vue
         uses: xRealNeon/VuePagesAction@1.0.0
         with:


### PR DESCRIPTION
**Descriptive Title**
Updates actions to version 4

**Changes**
In an attempt to fix the failure happening in Android build, the actions for checkout, java, and node are being updated to v4.
